### PR TITLE
Fix race in tests.

### DIFF
--- a/spec/capture-output_spec.rb
+++ b/spec/capture-output_spec.rb
@@ -3,14 +3,16 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe Capture do
   it "#stdout should capture all STDOUT IO content" do
 		Capture.stdout do
-			Process.spawn('echo "hello world"')
+			pid = Process.spawn('echo "hello world"')
+			Process.wait pid
 			STDOUT.puts 'puts'
 		end.should == "hello world\nputs\n"
   end
 
   it "#stderr should capture all STDERR IO content" do
 		Capture.stderr do
-			Process.spawn('echo "hello world" 1>&2')
+			pid = Process.spawn('echo "hello world" 1>&2')
+			Process.wait pid
 			STDERR.puts 'puts'
 		end.should == "hello world\nputs\n"
   end
@@ -18,8 +20,10 @@ describe Capture do
 	it "#stdout and #stderr in combination" do
 		Capture.stdout do
 			Capture.stderr do
-				Process.spawn('echo "hello world out"')
-				Process.spawn('echo "hello world err" 1>&2')
+				pid = Process.spawn('echo "hello world out"')
+				Process.wait pid
+				pid = Process.spawn('echo "hello world err" 1>&2')
+				Process.wait pid
 			end.should == "hello world err\n"
 		end.should == "hello world out\n"
 	end


### PR DESCRIPTION
Hello.
I'm not a ruby programmer and may be wrong, but looks like I found a race in testsL

```
Failures:

  1) Capture #stdout should capture all STDOUT IO content
     Failure/Error: end.should == "hello world\nputs\n"
       expected: "hello world\nputs\n"
            got: "puts\nhello world\n" (using ==)
       Diff:

       @@ -1,3 +1,3 @@
       -hello world
        puts
       +hello world

     # ./spec/capture-output_spec.rb:8:in `block (2 levels) in <top (required)>'

  2) Capture #stderr should capture all STDERR IO content
     Failure/Error: end.should == "hello world\nputs\n"
       expected: "hello world\nputs\n"
            got: "puts\nhello world\n" (using ==)
       Diff:

       @@ -1,3 +1,3 @@
       -hello world
        puts
       +hello world

     # ./spec/capture-output_spec.rb:15:in `block (2 levels) in <top (required)>'

Finished in 0.00377 seconds
3 examples, 2 failures
```

Looks like reason is that Process.spawn dont wait for process termination, so we cant garantee the order of output.
After I changed the code, everything works as expected.
